### PR TITLE
dim(sim) > 5570

### DIFF
--- a/R/get_sim.R
+++ b/R/get_sim.R
@@ -114,3 +114,4 @@ get_sim <- function(conn, ano, agr,
 
   return(sim)
 }
+#dim(sim) > 5570


### PR DESCRIPTION
As agregações por 'cod_mun" retornam alguns valores inválidos, o que faz o número de municipios ficar maior que 5570.
EX: 
sim <- get_sim(conn = bancos, ano = 2015, agr = "mun")
dim(sim)
5592

A gente cria uma funcao no proadess pra retirar esses municipios ignorados, tipo essa abaixo, vou tentar adaptar pra cá:

Regrasmun <- function (var1) {

var1[var1=="179999"] <- "170000"
var1[var1=="170172"] <- "170000"
var1[var1=="171350"] <- "170000"
var1[var1=="172206"] <- "170000"
var1[substring(var1,1,2)=="53"] <- "530010"
var1[var1>=334501 & var1<= 334530] <- "330455"
var1[var1=="339999"] <- "330000"
var1[var1=="330064"] <- "330000"
var1[var1>=358001 & var1<= 358058] <- "355030"
var1[var1=="430145"] <- "431454"
var1[var1=="431453"] <- "431454"
var1
}